### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  http: ^0.13.6
+  http:  ^1.1.0
   intl: ^0.18.1
 
 dev_dependencies:


### PR DESCRIPTION
updated  http package from ^0.13.6 to ^1.1.0 
to fix the issue 

Because currency_converter >=0.0.4 depends on http ^0.13.6 and
  currency_converter <0.0.4 depends on http ^0.13.5, every version of
  currency_converter requires http ^0.13.5.
So, because faza3ah depends on both http ^1.1.0 and currency_converter any,
  version solving failed.